### PR TITLE
Refactor create_music logic to handle duplicate file paths

### DIFF
--- a/src-tauri/src/commands/music_commands.rs
+++ b/src-tauri/src/commands/music_commands.rs
@@ -56,12 +56,8 @@ pub fn create_music(file_path: String) -> Result<(), String> {
   let music_arg: MusicArg = match read_file_metadata(file_path) {
     Ok(arg) => arg,
     Err(err) => return Err(err),
-};
-  let destination_path: std::path::PathBuf = Path::new(AUDIO_STORE).join(music_arg.title.as_ref().unwrap());
-  if destination_path.exists() {
-      return Err("File already exists".to_string());
-  }
-
+  };
+  
   let mut connection: SqliteConnection = establish_connection();
 
   let new_music: NewMusic<'_> = NewMusic {

--- a/src-tauri/src/helper/files.rs
+++ b/src-tauri/src/helper/files.rs
@@ -37,12 +37,8 @@ pub fn create_audio_store_directory() -> Result<(), String> {
     Ok(())
 }
 
-pub fn copy_file_to_store(file_path: &str, file_name: &str) -> Result<String, String> {
-    let destination_path: std::path::PathBuf = Path::new(AUDIO_STORE).join(file_name);
-    if destination_path.exists() {
-        return Err("File already exists".to_string());
-    }
+pub fn copy_file_to_destination(file_path: &str, destination_path: &str) -> Result<(), String> {
     fs::copy(file_path, &destination_path)
         .map_err(|e| format!("Unable to copy file: {}", e))?;
-    Ok(destination_path.to_str().unwrap().to_string())
+    Ok(())
 }

--- a/src-tauri/src/helper/files.rs
+++ b/src-tauri/src/helper/files.rs
@@ -39,6 +39,9 @@ pub fn create_audio_store_directory() -> Result<(), String> {
 
 pub fn copy_file_to_store(file_path: &str, file_name: &str) -> Result<String, String> {
     let destination_path: std::path::PathBuf = Path::new(AUDIO_STORE).join(file_name);
+    if destination_path.exists() {
+        return Err("File already exists".to_string());
+    }
     fs::copy(file_path, &destination_path)
         .map_err(|e| format!("Unable to copy file: {}", e))?;
     Ok(destination_path.to_str().unwrap().to_string())

--- a/src/components/SideNavigation.tsx
+++ b/src/components/SideNavigation.tsx
@@ -85,7 +85,7 @@ export const SideNavigation = () => {
                 </TextField>
                 <Button 
                   class="w-20 mt-5" size={"sm"} 
-                  onClick={() => playlistTitle().trim() !== "" ? (addPlaylist(playlistTitle()), triggerModal) : triggerModal()}
+                  onClick={() => playlistTitle().trim() !== "" ? (addPlaylist(playlistTitle()), triggerModal()) : triggerModal()}
                   disabled={playlistTitle().trim() === ""}
                   variant={"filled"} 
                 >

--- a/src/components/SideNavigation.tsx
+++ b/src/components/SideNavigation.tsx
@@ -13,7 +13,6 @@ import { TextField, TextFieldInput } from "./TextField"
 
 export const SideNavigation = () => {
   const [isAddPlaylistModalOpen, setIsAddPlaylistModalOpen] = createSignal(false);
-  const closePlaylistModal = () => setIsAddPlaylistModalOpen(false);
   const [playlistTitle, setPlaylistTitle] = createSignal("");
   
   let playlistRef!: HTMLDivElement;
@@ -44,7 +43,7 @@ export const SideNavigation = () => {
     await invoke("create_playlist", { playlistArg });
     fetchPlaylists();
     scrollToBottom();
-    closePlaylistModal();
+    setPlaylistTitle("");
   }
 
   function scrollToBottom() {


### PR DESCRIPTION
The logic handling copy to audio_store was flawed and produced bugs.

Changes:
- tag duplicate audios with a suffix, which will eliminate conflict between two different entries having the same audio file path
- handle the logic inside `read_metadata` in `create_music` command, generalizing the `copy_file_to_store` to as a util
- rename `copy_file_to_store` -> `copy_file_to_destination`