### PR TITLE
Fix yt-dlp download for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.js linguist-language=JavaScript
 *.css linguist-language=CSS
 *.html linguist-language=HTML
+*.exe filter=lfs diff=lfs merge=lfs -text

--- a/src-tauri/static/bin/ffmpeg.exe
+++ b/src-tauri/static/bin/ffmpeg.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4ca243a46b83d3415527db52eb431aa6aece11fd9cacd519a44ffe18a8717ff
+size 131088896


### PR DESCRIPTION
- used executable path in place of command name
- use lfs to store large ffmpeg.exe